### PR TITLE
Honor container health checks when present

### DIFF
--- a/environments/novnc_ubuntu/Dockerfile
+++ b/environments/novnc_ubuntu/Dockerfile
@@ -1,6 +1,8 @@
 FROM govindhud/novnc-ubuntu:latest
 COPY . /controller
 RUN pip install -e /controller --break-system-packages
+HEALTHCHECK --interval=5s --timeout=3s --retries=1 \
+    CMD wget -q --spider http://localhost:8080 || exit 1
 
 # note: when you make changes to the controller, hud-sdk will automatically reinstall the python package corresponding to the controller before every step.
 # Any changes to the Dockerfile though will only be reflected on the next environment creation

--- a/hud/env/environment.py
+++ b/hud/env/environment.py
@@ -81,7 +81,9 @@ class Environment(BaseModel):
             elif self.task and self.task.setup is not None:
                 await self._invoke_all(self.task.setup)
             else:
-                raise ValueError("No config, task or task setup function provided for local environment")
+                raise ValueError(
+                    "No config, task or task setup function provided for local environment"
+                )
 
     async def evaluate(self, config: FunctionConfigs | None = None) -> Any:
         """

--- a/hud/env/environment.py
+++ b/hud/env/environment.py
@@ -78,10 +78,10 @@ class Environment(BaseModel):
         else:
             if config is not None:
                 await self._invoke_all(config)
-            elif self.task and self.task.config is not None:
-                await self._invoke_all(self.task.config)
+            elif self.task and self.task.setup is not None:
+                await self._invoke_all(self.task.setup)
             else:
-                raise ValueError("No config or task provided for local environment")
+                raise ValueError("No config, task or task setup function provided for local environment")
 
     async def evaluate(self, config: FunctionConfigs | None = None) -> Any:
         """
@@ -98,8 +98,8 @@ class Environment(BaseModel):
         else:
             if config is not None:
                 results = await self._invoke_all(config)
-            elif self.task and self.task.config is not None:
-                results = await self._invoke_all(self.task.config)
+            elif self.task and self.task.evaluate is not None:
+                results = await self._invoke_all(self.task.evaluate)
             else:
                 raise ValueError("No config or task provided for local environment")
         if len(results) == 1:

--- a/hud/env/local_docker_client.py
+++ b/hud/env/local_docker_client.py
@@ -4,8 +4,8 @@ import asyncio
 import io
 import logging
 import textwrap
-import uuid
 import time
+import uuid
 from typing import TYPE_CHECKING, Any
 
 import aiodocker
@@ -42,7 +42,7 @@ class LocalDockerClient(DockerClient):
 
         # Create a tar file from the path
         tar_bytes = directory_to_tar_bytes(build_context)
-        logger.info("generated tar file with size: %d KB", len(tar_bytes)//1024)
+        logger.info("generated tar file with size: %d KB", len(tar_bytes) // 1024)
 
         # Build the image
         build_stream = await docker_client.images.build(
@@ -63,10 +63,10 @@ class LocalDockerClient(DockerClient):
 
         return image_tag, {"build_output": output}
 
-
     @classmethod
     async def create(
-        cls, image: str,
+        cls,
+        image: str,
     ) -> LocalDockerClient:
         """
         Creates a Docker environment client from a image.
@@ -77,7 +77,7 @@ class LocalDockerClient(DockerClient):
         Returns:
             DockerClient: An instance of the Docker environment client
         """
-       
+
         # Initialize Docker client
         docker_client = aiodocker.Docker()
 
@@ -102,9 +102,8 @@ class LocalDockerClient(DockerClient):
             window_usecs = health_check_config.get("Interval", int(30 * 1e9))
             window_secs = window_usecs // 1_000_000
 
-            now = time.monotonic()
-            deadline = now + window_secs
-            logger.debug(f"Waiting for container {container.id} to become healthy")
+            deadline = time.monotonic() + window_secs
+            logger.debug("Waiting for container %s to become healthy", container.id)
             while True:
                 state = (await container.show())["State"]
                 if state.get("Health", {}).get("Status") == "healthy":
@@ -115,7 +114,7 @@ class LocalDockerClient(DockerClient):
                 if now > deadline:
                     raise TimeoutError(f"{container.id} not healthy after {window_secs}s")
                 await asyncio.sleep(1)
-            logger.debug(f"Container {container.id} is healthy")
+            logger.debug("Container %s is healthy", container.id)
 
         # Return the controller instance
         return cls(docker_client, container.id)
@@ -213,7 +212,6 @@ class LocalDockerClient(DockerClient):
                 stdout_data.extend(message.data)
             elif message.stream == 2:  # stderr
                 stderr_data.extend(message.data)
-
 
         if "No module named 'hud_controller'" in stderr_data.decode():
             if self._source_path is None:


### PR DESCRIPTION
Before adding this, code such as this:
```
import asyncio
from pathlib import Path
from hud.types import CustomGym
from hud import gym

import logging
logging.basicConfig(level=logging.DEBUG)

async def main():
    env_spec = CustomGym(
        location="local",
        image_or_build_context=Path("environments/novnc_ubuntu")
    )
    env = await gym.make(env_spec)
    print("Environment created, sleeping")
    # await asyncio.sleep(3)
    step = await env.reset()

if __name__ == "__main__":
    asyncio.run(main())
```

would fail without uncommenting the sleep, since the novnc entrypoint takes a few seconds to spin up, and calling `reset`, `step` etc would throw arcane Xauth errors. 

Additionally bringing in the obvious bugfix from @socpite's branch so we can merge it sooner.